### PR TITLE
✨  Update functionality to allow repo's with merge queue enabled

### DIFF
--- a/bulk_merger.rb
+++ b/bulk_merger.rb
@@ -21,7 +21,7 @@ class BulkMerger
 
     return if list
 
-    puts "\nHave you reviewed the changes, and you want to approve all these PRs? [y/N]\n"
+    puts "\nHave you reviewed the changes, and do you want to approve all these PRs? [y/N]\n"
     if STDIN.gets.chomp == "y"
       puts "OK! 👍 Approving away..."
     else
@@ -56,7 +56,7 @@ class BulkMerger
       puts "- '#{pr.title}' (#{pr.html_url}) "
     end
 
-    puts "\nHave you reviewed the changes, and you want to process all these PRs? [y/N]\n"
+    puts "\nHave you reviewed the changes, and do you want to MERGE all these PRs? [y/N]\n"
     if STDIN.gets.chomp == "y"
       unmerged_pull_requests.each do |pr|
         repo = pr.repository_url.gsub("https://api.github.com/repos/", "")

--- a/bulk_merger.rb
+++ b/bulk_merger.rb
@@ -62,7 +62,6 @@ class BulkMerger
         repo = pr.repository_url.gsub("https://api.github.com/repos/", "")
         if merge_queue_enabled?(repo)
           begin
-            # Assuming `add_to_merge_queue` is a method that adds a PR to the merge queue
             pull_request_id = get_pull_request_id(repo, pr.number)
             add_to_merge_queue(repo, pull_request_id)
             puts "✅ Added PR '#{pr.title}' to the merge queue"


### PR DESCRIPTION
This PR adds functionality for merge-queue enabled repositories while keeping existing functionality working as expected. 

It does this by using the new methods added to query GitHub to check if a merge-queue is enabled or not and then processing the PR accordingly.